### PR TITLE
Padding around new game elements. Move dice in line with drop downs.

### DIFF
--- a/core/src/main/java/de/sesu8642/feudaltactics/frontend/ui/screens/IngameScreen.java
+++ b/core/src/main/java/de/sesu8642/feudaltactics/frontend/ui/screens/IngameScreen.java
@@ -50,10 +50,6 @@ import de.sesu8642.feudaltactics.frontend.ui.stages.ParameterInputStage;
 @Singleton
 public class IngameScreen extends GameScreen {
 
-	private static final long BUTTON_HEIGHT_PX = 110;
-	private static final long INPUT_HEIGHT_PX = 79;
-	private static final long INPUT_WIDTH_PX = 419;
-
 	private AutoSaveRepository autoSaveRepo;
 	private MainPreferencesDao mainPrefsDao;
 
@@ -280,13 +276,13 @@ public class IngameScreen extends GameScreen {
 		// calculate what is the bigger rectangular area for the map to fit: above the
 		// inputs or to their right
 		float aboveArea = ingameCamera.viewportWidth
-				* (ingameCamera.viewportHeight - BUTTON_HEIGHT_PX - ParameterInputStage.NO_OF_INPUTS * INPUT_HEIGHT_PX);
-		float rightArea = (ingameCamera.viewportWidth - INPUT_WIDTH_PX)
-				* (ingameCamera.viewportHeight - BUTTON_HEIGHT_PX);
+				* (ingameCamera.viewportHeight - ParameterInputStage.TOTAL_INPUT_HEIGHT);
+		float rightArea = (ingameCamera.viewportWidth - ParameterInputStage.TOTAL_INPUT_WIDTH)
+				* (ingameCamera.viewportHeight - ParameterInputStage.BUTTON_HEIGHT_PX);
 		if (aboveArea > rightArea) {
-			return new Margin(0, BUTTON_HEIGHT_PX + ParameterInputStage.NO_OF_INPUTS * INPUT_HEIGHT_PX, 0, 0);
+			return new Margin(0, ParameterInputStage.TOTAL_INPUT_HEIGHT, 0, 0);
 		} else {
-			return new Margin(INPUT_WIDTH_PX, BUTTON_HEIGHT_PX, 0, 0);
+			return new Margin(ParameterInputStage.TOTAL_INPUT_WIDTH, ParameterInputStage.BUTTON_HEIGHT_PX, 0, 0);
 		}
 	}
 

--- a/core/src/main/java/de/sesu8642/feudaltactics/frontend/ui/stages/ParameterInputStage.java
+++ b/core/src/main/java/de/sesu8642/feudaltactics/frontend/ui/stages/ParameterInputStage.java
@@ -103,12 +103,13 @@ public class ParameterInputStage extends ResizableResettableStage {
 		randomButton.getImageCell().expand().fill();
 		playButton = new TextButton("Play", skin);
 
-		// The largest element on the screen is the seed text field. Measure the largest possible
-		// size of this, based on the max number of chars allowed (18), and in case the font is not
-		// a monospace font, choose a number that takes lots of space (7).
-		// Then, add a little bit extra for the UI component border.
-		GlyphLayout seedWidthRuler = new GlyphLayout(seedTextField.getStyle().font, "777777777777777777");
-		float seedLabelWidth = seedWidthRuler.width * 1.2f;
+		/*
+		 * The longest text on the screen is the seed text field. It allows for 18
+		 * characters at max and 7 is the widest number. Scrolling the text is possible.
+		 * Generated seeds are normally much shorter than the worst case (only 7s).
+		 */
+		float maxSeedNumberWidth = new GlyphLayout(seedTextField.getStyle().font, "7").width;
+		float seedTextFieldWidth = maxSeedNumberWidth * 20;
 
 		rootTable = new Table();
 		rootTable.setFillParent(true);
@@ -127,7 +128,7 @@ public class ParameterInputStage extends ResizableResettableStage {
 		rootTable.add(densitySelect).colspan(2).fillX();
 		rootTable.row().pad(10);
 		rootTable.add(seedLabel);
-		rootTable.add(seedTextField).minWidth(seedLabelWidth);
+		rootTable.add(seedTextField).minWidth(seedTextFieldWidth);
 		rootTable.add(randomButton).height(Value.percentHeight(1, seedTextField)).width(Value.percentHeight(1))
 				.padLeft(10);
 		rootTable.row().pad(10);

--- a/core/src/main/java/de/sesu8642/feudaltactics/frontend/ui/stages/ParameterInputStage.java
+++ b/core/src/main/java/de/sesu8642/feudaltactics/frontend/ui/stages/ParameterInputStage.java
@@ -6,6 +6,7 @@ import java.util.stream.Stream;
 
 import javax.inject.Inject;
 
+import com.badlogic.gdx.graphics.g2d.GlyphLayout;
 import com.badlogic.gdx.graphics.g2d.TextureAtlas;
 import com.badlogic.gdx.scenes.scene2d.Actor;
 import com.badlogic.gdx.scenes.scene2d.Stage;
@@ -102,27 +103,34 @@ public class ParameterInputStage extends ResizableResettableStage {
 		randomButton.getImageCell().expand().fill();
 		playButton = new TextButton("Play", skin);
 
+		// The largest element on the screen is the seed text field. Measure the largest possible
+		// size of this, based on the max number of chars allowed (18), and in case the font is not
+		// a monospace font, choose a number that takes lots of space (7).
+		// Then, add a little bit extra for the UI component border.
+		GlyphLayout seedWidthRuler = new GlyphLayout(seedTextField.getStyle().font, "777777777777777777");
+		float seedLabelWidth = seedWidthRuler.width * 1.2f;
+
 		rootTable = new Table();
 		rootTable.setFillParent(true);
 		rootTable.defaults().left();
 		rootTable.columnDefaults(0).pad(0, 10, 0, 10);
 		rootTable.add().expandY();
-		rootTable.row();
+		rootTable.row().pad(10);
 		rootTable.add(difficultyLabel);
-		rootTable.add(difficultySelect);
+		rootTable.add(difficultySelect).colspan(2).fillX();
 		rootTable.add().expandX();
-		rootTable.row();
+		rootTable.row().pad(10);
 		rootTable.add(sizeLabel);
-		rootTable.add(sizeSelect);
-		rootTable.row();
+		rootTable.add(sizeSelect).colspan(2).fillX();
+		rootTable.row().pad(10);
 		rootTable.add(densityLabel);
-		rootTable.add(densitySelect);
-		rootTable.row();
+		rootTable.add(densitySelect).colspan(2).fillX();
+		rootTable.row().pad(10);
 		rootTable.add(seedLabel);
-		rootTable.add(seedTextField).prefWidth(Value.percentWidth(1, difficultySelect));
+		rootTable.add(seedTextField).minWidth(seedLabelWidth);
 		rootTable.add(randomButton).height(Value.percentHeight(1, seedTextField)).width(Value.percentHeight(1))
 				.padLeft(10);
-		rootTable.row();
+		rootTable.row().pad(10);
 		rootTable.add(playButton).colspan(4).fillX();
 		this.addActor(rootTable);
 

--- a/core/src/main/java/de/sesu8642/feudaltactics/frontend/ui/stages/ParameterInputStage.java
+++ b/core/src/main/java/de/sesu8642/feudaltactics/frontend/ui/stages/ParameterInputStage.java
@@ -39,8 +39,21 @@ import de.sesu8642.feudaltactics.frontend.persistence.NewGamePreferencesDao;
  */
 public class ParameterInputStage extends ResizableResettableStage {
 
+	private static final long INPUT_HEIGHT_PX = 79;
+	private static final int INPUT_PADDING_PX = 20;
+	private static final int OUTTER_PADDING_PX = 10;
+
 	// for map centering calculation
-	public static final int NO_OF_INPUTS = 4;
+	/** Height of the play button. */
+	public static final long BUTTON_HEIGHT_PX = 110;
+
+	/** Height of all parameter inputs combined. */
+	public static final long TOTAL_INPUT_HEIGHT = 4 * (INPUT_HEIGHT_PX + INPUT_PADDING_PX) + BUTTON_HEIGHT_PX
+			+ OUTTER_PADDING_PX;
+	/**
+	 * Width of all parameter inputs combined; depends on label texts and used font.
+	 */
+	public static final long TOTAL_INPUT_WIDTH = 509;
 
 	private EventBus eventBus;
 	private NewGamePreferencesDao newGamePrefDao;
@@ -113,26 +126,27 @@ public class ParameterInputStage extends ResizableResettableStage {
 
 		rootTable = new Table();
 		rootTable.setFillParent(true);
-		rootTable.defaults().left();
-		rootTable.columnDefaults(0).pad(0, 10, 0, 10);
+		rootTable.defaults().left().pad(INPUT_PADDING_PX / 2F, 0, INPUT_PADDING_PX / 2F, 0);
+		rootTable.columnDefaults(0).pad(0, OUTTER_PADDING_PX, 0, OUTTER_PADDING_PX);
 		rootTable.add().expandY();
-		rootTable.row().pad(10);
+		rootTable.row();
 		rootTable.add(difficultyLabel);
 		rootTable.add(difficultySelect).colspan(2).fillX();
 		rootTable.add().expandX();
-		rootTable.row().pad(10);
+		rootTable.row();
 		rootTable.add(sizeLabel);
 		rootTable.add(sizeSelect).colspan(2).fillX();
-		rootTable.row().pad(10);
+		rootTable.row();
 		rootTable.add(densityLabel);
 		rootTable.add(densitySelect).colspan(2).fillX();
-		rootTable.row().pad(10);
+		rootTable.row();
 		rootTable.add(seedLabel);
 		rootTable.add(seedTextField).minWidth(seedTextFieldWidth);
 		rootTable.add(randomButton).height(Value.percentHeight(1, seedTextField)).width(Value.percentHeight(1))
 				.padLeft(10);
-		rootTable.row().pad(10);
-		rootTable.add(playButton).colspan(4).fillX();
+		rootTable.row();
+		rootTable.add(playButton).colspan(4).fillX().pad(INPUT_PADDING_PX / 2F, OUTTER_PADDING_PX, OUTTER_PADDING_PX,
+				OUTTER_PADDING_PX);
 		this.addActor(rootTable);
 
 		registerEventListeners();


### PR DESCRIPTION
As per #42, this tweaks the UI on the game start screen to add some padding and shuffle the random button in line with other buttons. After viewing this change, I'm pretty happy with the outcome.

Also think that on a landscape screen, perhaps the "Play" button could be moved to the left side with a similar width as the other buttons (though in portrait, should probably still take the whole screen). Anyway, that is a thought for another time.

# TODO

* Test on Android

# Screenshots

## Desktop 1920x1080

![image](https://user-images.githubusercontent.com/248565/220506545-a04e4e83-b41a-4cec-ac58-5ea60eacaa97.png)

## Desktop (shrunk to simulate phone portrait mode)

<img src="https://user-images.githubusercontent.com/248565/220506746-dbf011d2-eb64-40d4-ab91-71ea485acbd3.png" width="300" />  <img src="https://user-images.githubusercontent.com/248565/220506969-3cd3662f-79bc-4095-b6f3-e7d01bd851dc.png" width="300" />

