### PR TITLE
Add ability to combine two spearmen (issue #77)

### DIFF
--- a/core/src/main/java/de/sesu8642/feudaltactics/lib/gamestate/GameStateHelper.java
+++ b/core/src/main/java/de/sesu8642/feudaltactics/lib/gamestate/GameStateHelper.java
@@ -447,29 +447,14 @@ public class GameStateHelper {
 	 */
 	public static void combineUnits(GameState gameState, HexTile tile) {
 		// place resulting unit as held object
-		// the unit that is not the peasant will be upgraded
-		Unit oldUnit;
-		if (((Unit) tile.getContent()).getUnitType() == UnitTypes.PEASANT) {
-			oldUnit = (Unit) gameState.getHeldObject();
-		} else {
-			oldUnit = (Unit) tile.getContent();
-		}
-		UnitTypes newUnitType = null;
-		switch (oldUnit.getUnitType()) {
-		case PEASANT:
-			newUnitType = UnitTypes.SPEARMAN;
-			break;
-		case SPEARMAN:
-			newUnitType = UnitTypes.KNIGHT;
-			break;
-		case KNIGHT:
-			newUnitType = UnitTypes.BARON;
-			break;
-		default:
-			break;
-		}
+		Unit heldUnit = (Unit) gameState.getHeldObject();
+		Unit tileUnit = (Unit) tile.getContent();
+
+		int newStrength = heldUnit.getStrength() + tileUnit.getStrength();
+		UnitTypes newUnitType = UnitTypes.ofStrength(newStrength);
+
 		Unit newUnit = new Unit(newUnitType);
-		newUnit.setCanAct(((Unit) tile.getContent()).isCanAct());
+		newUnit.setCanAct(tileUnit.isCanAct());
 		gameState.setHeldObject(newUnit);
 		placeObject(gameState, tile);
 	}

--- a/core/src/main/java/de/sesu8642/feudaltactics/lib/gamestate/InputValidationHelper.java
+++ b/core/src/main/java/de/sesu8642/feudaltactics/lib/gamestate/InputValidationHelper.java
@@ -279,14 +279,10 @@ public class InputValidationHelper {
 		if (!ClassReflection.isAssignableFrom(Unit.class, tile.getContent().getClass())) {
 			return false;
 		}
-		if (((Unit) gameState.getHeldObject()).getUnitType() != UnitTypes.PEASANT
-				&& ((Unit) tile.getContent()).getUnitType() != UnitTypes.PEASANT) {
-			// not at least one peasant
-			return false;
-		}
-		if (((Unit) gameState.getHeldObject()).getUnitType() == UnitTypes.BARON
-				|| ((Unit) tile.getContent()).getUnitType() == UnitTypes.BARON) {
-			// cannot upgrade a baron
+		int heldUnitStrength = ((Unit) gameState.getHeldObject()).getStrength();
+		int tileUnitStrength = ((Unit) tile.getContent()).getStrength();
+		if (heldUnitStrength + tileUnitStrength > UnitTypes.strongest().strength()) {
+			// cannot create unit stronger than the strongest unit
 			return false;
 		}
 		return true;

--- a/core/src/main/java/de/sesu8642/feudaltactics/lib/ingame/botai/BotAi.java
+++ b/core/src/main/java/de/sesu8642/feudaltactics/lib/ingame/botai/BotAi.java
@@ -379,6 +379,7 @@ public class BotAi {
 			pickedUpUnits.removeUnit(UnitTypes.SPEARMAN);
 			pickedUpUnits.removeUnit(UnitTypes.SPEARMAN);
 			pickedUpUnits.addUnit(UnitTypes.BARON);
+			return true;
 		} else if (pickedUpUnits.ofType(UnitTypes.KNIGHT) >= 1
 				&& (GameStateHelper.getKingdomIncome(kingdom)
 						- getActualKingdomSalaries(gameState, kingdom, pickedUpUnits) - UnitTypes.BARON.salary()
@@ -387,6 +388,16 @@ public class BotAi {
 			// buy 1 peasant and combine with an existing knight
 			kingdom.setSavings(kingdom.getSavings() - Unit.COST);
 			pickedUpUnits.removeUnit(UnitTypes.KNIGHT);
+			pickedUpUnits.addUnit(UnitTypes.BARON);
+			return true;
+		} else if (pickedUpUnits.ofType(UnitTypes.SPEARMAN) >= 1
+				&& (GameStateHelper.getKingdomIncome(kingdom)
+				- getActualKingdomSalaries(gameState, kingdom, pickedUpUnits) - UnitTypes.BARON.salary()
+				+ UnitTypes.SPEARMAN.salary() >= 0 || kingdom.getSavings() > UnitTypes.BARON.salary() * 3)
+				&& kingdom.getSavings() >= 2 * Unit.COST) {
+			// buy 2 peasants and combine with an existing spearman
+			kingdom.setSavings(kingdom.getSavings() - (2 * Unit.COST));
+			pickedUpUnits.removeUnit(UnitTypes.SPEARMAN);
 			pickedUpUnits.addUnit(UnitTypes.BARON);
 			return true;
 		} else if (canKingdomSustainNewUnit(gameState, kingdom, pickedUpUnits, UnitTypes.BARON)) {

--- a/core/src/main/java/de/sesu8642/feudaltactics/lib/ingame/botai/BotAi.java
+++ b/core/src/main/java/de/sesu8642/feudaltactics/lib/ingame/botai/BotAi.java
@@ -376,6 +376,7 @@ public class BotAi {
 			pickedUpUnits.addUnit(UnitTypes.BARON);
 			return true;
 		} else if (pickedUpUnits.ofType(UnitTypes.SPEARMAN) >= 2) {
+			// combine two spearmen
 			pickedUpUnits.removeUnit(UnitTypes.SPEARMAN);
 			pickedUpUnits.removeUnit(UnitTypes.SPEARMAN);
 			pickedUpUnits.addUnit(UnitTypes.BARON);
@@ -392,8 +393,8 @@ public class BotAi {
 			return true;
 		} else if (pickedUpUnits.ofType(UnitTypes.SPEARMAN) >= 1
 				&& (GameStateHelper.getKingdomIncome(kingdom)
-				- getActualKingdomSalaries(gameState, kingdom, pickedUpUnits) - UnitTypes.BARON.salary()
-				+ UnitTypes.SPEARMAN.salary() >= 0 || kingdom.getSavings() > UnitTypes.BARON.salary() * 3)
+						- getActualKingdomSalaries(gameState, kingdom, pickedUpUnits) - UnitTypes.BARON.salary()
+						+ UnitTypes.SPEARMAN.salary() >= 0 || kingdom.getSavings() > UnitTypes.BARON.salary() * 3)
 				&& kingdom.getSavings() >= 2 * Unit.COST) {
 			// buy 2 peasants and combine with an existing spearman
 			kingdom.setSavings(kingdom.getSavings() - (2 * Unit.COST));

--- a/core/src/main/java/de/sesu8642/feudaltactics/lib/ingame/botai/BotAi.java
+++ b/core/src/main/java/de/sesu8642/feudaltactics/lib/ingame/botai/BotAi.java
@@ -375,6 +375,10 @@ public class BotAi {
 			pickedUpUnits.removeUnit(UnitTypes.KNIGHT);
 			pickedUpUnits.addUnit(UnitTypes.BARON);
 			return true;
+		} else if (pickedUpUnits.ofType(UnitTypes.SPEARMAN) >= 2) {
+			pickedUpUnits.removeUnit(UnitTypes.SPEARMAN);
+			pickedUpUnits.removeUnit(UnitTypes.SPEARMAN);
+			pickedUpUnits.addUnit(UnitTypes.BARON);
 		} else if (pickedUpUnits.ofType(UnitTypes.KNIGHT) >= 1
 				&& (GameStateHelper.getKingdomIncome(kingdom)
 						- getActualKingdomSalaries(gameState, kingdom, pickedUpUnits) - UnitTypes.BARON.salary()


### PR DESCRIPTION
Rework unit combination logic to allow two spearmen to be combined.

Not sure if two spearmen are supposed to be able to be combined, but if so this will allow for it.